### PR TITLE
feat: Add frontend image definition for podcast engineering environment

### DIFF
--- a/.devcenter/catalog/image-definitions/frontend-image-definition.yaml
+++ b/.devcenter/catalog/image-definitions/frontend-image-definition.yaml
@@ -1,0 +1,24 @@
+$schema: "1.0"
+name: "frontend-image"
+description: "This definition is for the podcast frontend engineering environment"
+
+image: "microsoftvisualstudio_windowsplustools_base-win11-gen2"
+enableScheduledRefresh: true
+scheduledTimePeriod: hour
+scheduledRecurrence: 24
+
+tasks:
+  ### Run common DSC configurations for contoso engineering environments to create Dev Drive and install common tools
+  - name: winget
+    parameters:
+      downloadUrl: 'https://raw.githubusercontent.com/contoso-co/common-eng-sys/main/dsc-configurations/common-config.dsc.yaml'
+  ### Clone the podcast repository into the Workspaces directory
+  - name: git-clone
+    description: Clone this repository into z:\
+    parameters:
+      repositoryUrl: https://github.com/sebafo/podcastApp.git
+      directory: z:\
+  ### Run the DSC configuration for the frontend engineering environment
+  # - name: winget
+  #   parameters:
+  #     configurationFile: 'z:\workspaces\eshop\.configurations\maui.dsc.yaml'


### PR DESCRIPTION
This pull request introduces a new YAML file, `frontend-image-definition.yaml`, in the `.devcenter/catalog/image-definitions` directory. The file defines a new image for the podcast frontend engineering environment.