### PR TITLE
feat: Add devbox customization tasks for VSCode, Node.js, and reposit…

### DIFF
--- a/.devcenter/catalog/config-as-code/workload.yaml
+++ b/.devcenter/catalog/config-as-code/workload.yaml
@@ -1,0 +1,14 @@
+$schema: "1.0"
+name: "devbox-customization"
+tasks:
+  - name: choco
+    parameters:
+      package: vscode
+  - name: choco
+    parameters:
+      package: nodejs
+  - name: git-clone
+    description: Clone this repository into z:\
+    parameters:
+      repositoryUrl: https://github.com/sebafo/podcastApp.git
+      directory: z:\


### PR DESCRIPTION
This pull request introduces a new configuration file, `workload.yaml`, in the `.devcenter/catalog/config-as-code` directory. The file defines a "devbox-customization" task which includes three sub-tasks: two `choco` tasks for installing `vscode` and `nodejs`, and a `git-clone` task for cloning a specific repository into the `z: directory